### PR TITLE
Add support for initWithCoder to permit use with nibs

### DIFF
--- a/FSLineChart/FSLineChart/FSLineChart.m
+++ b/FSLineChart/FSLineChart/FSLineChart.m
@@ -40,10 +40,24 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        self.backgroundColor = [UIColor whiteColor];
-        [self setDefaultParameters];
+        [self commonInit];
     }
     return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
+    self.backgroundColor = [UIColor whiteColor];
+    [self setDefaultParameters];
 }
 
 - (void)setChartData:(NSArray *)chartData


### PR DESCRIPTION
Added an `initWithCoder` method to FSLineChart.m to support its use directly from a nib. Moved the setup in `initWithFrame` to a common init method.