### PR TITLE
Add labelling position enum option to mirror right labelling on left

### DIFF
--- a/FSLineChart/FSLineChart/FSLineChart.h
+++ b/FSLineChart/FSLineChart/FSLineChart.h
@@ -31,7 +31,8 @@ typedef NSString *(^FSLabelForValueGetter)(CGFloat value);
 
 typedef NS_ENUM(NSInteger, ValueLabelPositionType) {
     ValueLabelLeft,
-    ValueLabelRight
+    ValueLabelRight,
+    ValueLabelLeftMirrored
 };
 
 // Index label properties

--- a/FSLineChart/FSLineChart/FSLineChart.m
+++ b/FSLineChart/FSLineChart/FSLineChart.m
@@ -99,7 +99,10 @@
              context:nil]
             .size.width;
             
-            UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(p.x - width - 6, p.y + 2, width + 2, 14)];
+            CGFloat xPadding = 6;
+            CGFloat xOffset = (_valueLabelPosition == ValueLabelRight ? width + xPadding : 0 - xPadding);
+            
+            UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(p.x - xOffset, p.y + 2, width + 2, 14)];
             label.text = text;
             label.font = _valueLabelFont;
             label.textColor = _valueLabelTextColor;

--- a/FSLineChart/FSLineChart/FSLineChart.m
+++ b/FSLineChart/FSLineChart/FSLineChart.m
@@ -100,7 +100,11 @@
             .size.width;
             
             CGFloat xPadding = 6;
-            CGFloat xOffset = (_valueLabelPosition == ValueLabelRight ? width + xPadding : 0 - xPadding);
+            CGFloat xOffset = width + xPadding;
+            
+            if (_valueLabelPosition == ValueLabelLeftMirrored) {
+                xOffset = -xPadding;
+            }
             
             UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(p.x - xOffset, p.y + 2, width + 2, 14)];
             label.text = text;


### PR DESCRIPTION
This adds a new `ValueLabelPositionType`, named `ValueLabelLeftMirrored`, which mirrors the right-hand label behaviour on the left (i.e. left-aligning and left-indenting vs. right-aligning and right-indenting).

### Example:

Right-align behaviour (`ValueLabelRight`):
![Right-align behaviour](http://i.imgur.com/IaXd4hw.png)

Mirrored left-align behaviour (`ValueLabelLeftMirrored`):
![Left-align behaviour](http://i.imgur.com/HMb61Yk.png)