### PR TITLE
Prevent crash when setting empty chart data

### DIFF
--- a/FSLineChart/FSLineChart/FSLineChart.m
+++ b/FSLineChart/FSLineChart/FSLineChart.m
@@ -62,6 +62,10 @@
 
 - (void)setChartData:(NSArray *)chartData
 {
+    if (chartData.count == 0) {
+        return;
+    }
+    
     _data = [NSMutableArray arrayWithArray:chartData];
     
     [self computeBounds];


### PR DESCRIPTION
Setting chart data to an empty array causes `getLinePath` to loop (due to unsigned integer underflow) and leak memory until it crashes. It also causes `scale` in `strokeChart` to be infinite as the chart has zero extent.

This PR guards setting empty data to prevent this.